### PR TITLE
Mysql backup now works

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ the `longs` directory. We retain any backups in `long` that are less old than `-
 The sidecar should make a backup immediately after starting and then every `--backup_freq` after that.
 
 If you need to restore your site you can simply `kubectl exec` into the backup container. Since it can see the main
-wordpress volume and the backup volume it can simply use `tar` to extract a backup back into the wordpress volume.
+wordpress volume and the backup volume it can simply use `tar` to extract a backup back into the wordpress volume. In
+the `/dst` directory you will see two sub-directories: `shorts` and `longs`. These hold the short term and long term
+backups respectively (e.g. backups controlled by `--backup_freq` and `--long_freq` respectively). In these directories
+you will see a bunch of other sub-directories, each named with a timestamp indicating when the corresponding backup was
+started. In these directories you will find a tarball holding the filesystem backup and a .gz file holding the
+`mysqldump` output.
 
 ## Redirects
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,5 +34,27 @@ services:
          - WP_TITLE=${WP_TITLE:-A Site}
          # WP_ADMIN_EMAIL is required or their startup script fails
          - WP_ADMIN_EMAIL=fake@nowhere.com
+      volumes:
+         - wp_data:/var/www/html
       ports:
          - "8888:80"
+   wordpress_backup:
+      depends_on:
+         - wordpress
+      build: ./wp_bak
+      restart: always
+      command:
+         - "--backup_freq=1m"
+         - "--short_keep=7m"
+         - "--long_freq=7m"
+         - "--long_keep=28m"
+         - "--db_host=maria"
+         - "--db_user=wordpress"
+         - "--db_pass=wordpress"
+      volumes:
+         - wp_data:/src
+         - wp_backup:/dst
+volumes:
+   wp_data: {}
+   wp_backup: {}
+

--- a/docker/wp_bak/Dockerfile
+++ b/docker/wp_bak/Dockerfile
@@ -1,7 +1,10 @@
 FROM mvpstudio/python:v4 as base
 
-# Install mariadb-client to get mysqldump cli
-RUN apt-get update && apt-get install -y mariadb-client
+# Install mariadb-client to get mysqldump cli. The mkdir and chmod here
+# are only necessary for the docker-compose stuff to work. Otherwise the
+# mounted /dst volume is owned by root and not writable.
+RUN apt-get update && apt-get install -y mariadb-client && \
+   mkdir /dst && chmod a+rwx /dst
 
 USER mvp
 COPY app /home/mvp/app

--- a/docker/wp_bak/Dockerfile
+++ b/docker/wp_bak/Dockerfile
@@ -1,5 +1,8 @@
 FROM mvpstudio/python:v4 as base
 
+# Install mariadb-client to get mysqldump cli
+RUN apt-get update && apt-get install -y mariadb-client
+
 USER mvp
 COPY app /home/mvp/app
 WORKDIR /home/mvp/app

--- a/docker/wp_bak/app/test_wp_back.py
+++ b/docker/wp_bak/app/test_wp_back.py
@@ -65,4 +65,3 @@ class TestWpBack(unittest.TestCase):
                 dir.mkdir()
 
             self.assertEqual(get_backup_list(base_path), backups)
-

--- a/docker/wp_bak/app/test_wp_back.py
+++ b/docker/wp_bak/app/test_wp_back.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timedelta
+import itertools
+from pathlib import Path
+import tempfile
 import unittest
-from datetime import timedelta
-from .wp_bak import make_timedelta
+
+from .wp_bak import DATE_TIME_RE, delete_too_old, get_backup_list, make_timedelta
 
 
 class TestWpBack(unittest.TestCase):
@@ -19,3 +23,46 @@ class TestWpBack(unittest.TestCase):
 
         t = make_timedelta('1m')
         self.assertEqual(t, timedelta(minutes=1))
+
+    def test_datetime_re(self):
+        self.assertIsNone(DATE_TIME_RE.fullmatch('202-04-05-11-50-00'))
+        self.assertIsNone(DATE_TIME_RE.fullmatch('2021-4-05-11-50-00'))
+        self.assertIsNone(DATE_TIME_RE.fullmatch('2021-04-05-11-50-00-more'))
+        self.assertIsNone(DATE_TIME_RE.fullmatch('extra-2021-04-05-11-50-00'))
+        self.assertIsNotNone(DATE_TIME_RE.fullmatch('2021-04-05-11-50-00'))
+
+    def test_delete_too_old(self):
+        # First create a temp dir for testing and then add some fake backups under that.
+        with tempfile.TemporaryDirectory() as base_dir:
+            base_path = Path(base_dir)
+            backups = [
+                base_path / '2021-04-02-11-00-00',
+                base_path / '2021-04-03-11-00-00',
+                base_path / '2021-04-04-11-00-00',
+                base_path / '2021-04-05-11-00-00']
+            for backup in backups:
+                backup.mkdir()
+                (backup / 'files.tar.gz').touch()
+                (backup / 'dbdump.sql.gz').touch()
+
+            delete_too_old(base_path, datetime(2021, 4, 5, 11), timedelta(days=2))
+            remaining = list(base_path.iterdir())
+
+            self.assertEqual(set(remaining), set(backups[-2:]))
+
+    def test_get_backup_list(self):
+        with tempfile.TemporaryDirectory() as base_dir:
+            base_path = Path(base_dir)
+            backups = [
+                base_path / '2021-04-02-11-00-00',
+                base_path / '2021-04-03-11-00-00',
+                base_path / '2021-04-04-11-00-00',
+                base_path / '2021-04-05-11-00-00']
+            others = [
+                base_path / 'foo',
+                base_path / '2021-04-03-11-00-00-copy']
+            for dir in itertools.chain(backups, others):
+                dir.mkdir()
+
+            self.assertEqual(get_backup_list(base_path), backups)
+

--- a/k8s/running/wordpress.tmpl.yml
+++ b/k8s/running/wordpress.tmpl.yml
@@ -77,7 +77,7 @@ spec:
           - name: wp-data
             mountPath: /var/www/html
       - name: wordpress-backup
-        image: mvpstudio/wordpress-backup:v020
+        image: mvpstudio/wordpress-backup:v022
         resources:
            limits:
               cpu: 0.1
@@ -85,11 +85,20 @@ spec:
            requests:
               cpu: 0.1
               memory: 200M
+        env:
+          - name: WORDPRESS_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mdbsecrets
+                key: user-password
         args:
            - "--backup_freq=1d"
            - "--short_keep=7d"
            - "--long_freq=7d"
            - "--long_keep=28d"
+           - "--db_host=mariadb"
+           - "--db_user=wordpress"
+           - "--db_pass=$(WORDPRESS_DB_PASSWORD)"
         securityContext:
            # www-data is what WordPress runs as and that is userid 33 in the WordPress container so our
            # sidecar needs to run as the same user so it can access any files written by WordPress.


### PR DESCRIPTION
To make it easy to find the DB backup as well as the files backups I changed the backup structure a bit: now it creates a timestamped _directory_ for each backup and then it puts the DB backup and files backups in there as separate files. I also changed the `longs` directory to use hard-links instead of copies which will reduce disk usage.

It's all up and running currently and it looks happy and healthy!

Fixes #20 